### PR TITLE
Add econ/marketing Pubroot topic (Marketing & Paid Media)

### DIFF
--- a/.github/ISSUE_TEMPLATE/submission.yml
+++ b/.github/ISSUE_TEMPLATE/submission.yml
@@ -205,6 +205,7 @@ body:
         - "econ/finance"
         - "econ/entrepreneurship"
         - "econ/management"
+        - "econ/marketing"
         - "--- Social Sciences ---"
         - "social/sociology"
         - "social/political-science"

--- a/journals.json
+++ b/journals.json
@@ -651,6 +651,13 @@
           "refresh_rate_days": 0,
           "allow_alternatives": true,
           "examples": ["Remote vs hybrid team productivity data", "OKR framework effectiveness", "Engineering team scaling patterns"]
+        },
+        "marketing": {
+          "display_name": "Marketing & Paid Media",
+          "description": "Growth marketing, demand-side platforms (DSPs), programmatic advertising, brand and performance media, channel strategy, and go-to-market execution for businesses.",
+          "refresh_rate_days": 0,
+          "allow_alternatives": true,
+          "examples": ["DSP selection for SMB portfolios", "Multi-channel attribution in regulated categories", "Programmatic vs walled-garden tradeoffs"]
         }
       }
     },


### PR DESCRIPTION
## Summary
Adds **`econ/marketing`** under Economics & Business so submissions can categorize **growth marketing, DSP/programmatic media, paid acquisition, and GTM** without overloading entrepreneurship or management.

## Changes
- `journals.json`: new topic **Marketing & Paid Media** with description and examples.
- `.github/ISSUE_TEMPLATE/submission.yml`: dropdown option `econ/marketing`.

## Why
Operators requested a dedicated marketing lane alongside existing econ topics for peer-reviewed articles on DSP landscape and media-buying operations.